### PR TITLE
Deprecate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,21 @@
 [package]
 name = "nonzero_signed"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Jacob Kiesel <kieseljake@gmail.com>"]
 documentation = "https://xaeroxe.github.io/nonzero_signed/doc/nonzero_signed/"
 repository = "https://github.com/Xaeroxe/nonzero_signed"
 keywords = ["nonzero", "signed", "zero", "number"]
 categories = ["data-structures", "memory-management"]
 license = "MIT/Apache-2.0"
-description = "A small set of types for signed nonzero integers."
+description = """
+DEPRECATED
+
+Rust's std lib stabilized their own signed NonZero types in Rust 1.33, please
+use those instead. You can find them in std::num or core::num.
+
+Description
+
+A small set of types for signed nonzero integers.
+"""
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ license = "MIT/Apache-2.0"
 description = """
 DEPRECATED
 
-Rust's std lib stabilized their own signed NonZero types in Rust 1.33, please
-use those instead. You can find them in std::num or core::num.
+Rust's std lib will stabilize their own signed NonZero types in Rust 1.34, please
+use those instead if you're using Rust 1.34 or greater. You can find them in
+std::num or core::num.
 
 Description
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # nonzero_signed [![Crates.io](https://img.shields.io/crates/v/nonzero_signed.svg)](https://crates.io/crates/nonzero_signed)
 
-## **DEPRECATED**
+## DEPRECATED
 
-Rust's std lib stabilized their own signed NonZero types in Rust 1.33, please use
-those instead. You can find them in `std::num` or `core::num`.
+Rust's std lib stabilized their own signed NonZero types in Rust 1.34, please use
+those instead if you're using Rust 1.34 or greater. You can find them in `std::num`
+or `core::num`.
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # nonzero_signed [![Crates.io](https://img.shields.io/crates/v/nonzero_signed.svg)](https://crates.io/crates/nonzero_signed)
 
+## **DEPRECATED**
+
+Rust's std lib stabilized their own signed NonZero types in Rust 1.33, please use
+those instead. You can find them in `std::num` or `core::num`.
+
+## Description
+
 This rust crate provides a small set of types for signed nonzero integers.
 
 This is implemented by wrapping nonzero unsigned types and casting as needed,

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+
+fn main() {
+    if let Ok(output) = Command::new("rustc").arg("-V").output() {
+        if output.status.success() {
+            if let Ok(stdout) = String::from_utf8(output.stdout) {
+                if let Some(minor_version) = stdout.split(".").nth(1).and_then(|v| v.parse::<u32>().ok()) {
+                    if minor_version > 33 {
+                        println!("cargo:rustc-cfg=new_rustc");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
-use std::num::*;
 use std::fmt;
+use std::num::*;
 
 macro_rules! impl_nonzero_fmt {
     ( ( $( $Trait: ident ),+ ) for $Ty: ident ) => {
@@ -28,6 +28,7 @@ macro_rules! def_signed {
             /// use nonzero_signed::NonZeroI32;
             /// assert_eq!(size_of::<Option<NonZeroI32>>(), size_of::<i32>());
             /// ```
+            #[deprecated(since = "1.0.3", note = "These became part of std::num in Rust 1.33, please use the std types instead of this crate.")]
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
             #[repr(transparent)]
             pub struct $name($inner);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! def_signed {
             /// use nonzero_signed::NonZeroI32;
             /// assert_eq!(size_of::<Option<NonZeroI32>>(), size_of::<i32>());
             /// ```
-            #[deprecated(since = "1.0.3", note = "These became part of std::num in Rust 1.33, please use the std types instead of this crate.")]
+            #[cfg_attr(new_rustc, deprecated(since = "1.0.3", note = "These became part of std::num in Rust 1.34, please use the std types instead of this crate."))]
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
             #[repr(transparent)]
             pub struct $name($inner);


### PR DESCRIPTION
Once Rust 1.34 comes out this crate will become deprecated.